### PR TITLE
Optimize navigation group activity checks

### DIFF
--- a/app/Helpers/NavigationHelper.php
+++ b/app/Helpers/NavigationHelper.php
@@ -2,30 +2,29 @@
 
 namespace App\Helpers;
 
-use Illuminate\Support\Facades\Request;
-
 class NavigationHelper
 {
     public static function isGroupActive(array $urls): bool
     {
+        $request = request();
+        $currentUrl = $request->url();
+        $currentPath = self::normalizePath($request->path());
+
         foreach ($urls as $url) {
             if (is_callable($url)) {
                 $url = $url();
             }
 
-            if (request()->url() === $url || request()->is(parse_url($url, PHP_URL_PATH))) {
+            if ($currentUrl === $url || $currentPath === self::getUrlPath($url)) {
                 return true;
             }
         }
+
         return false;
     }
 
     protected static function getUrlPath($url): string
     {
-        if (is_callable($url)) {
-            $url = $url();
-        }
-
         if (is_object($url) && method_exists($url, '__toString')) {
             $url = (string) $url;
         }


### PR DESCRIPTION
## Summary
- reduce repeated request lookups in NavigationHelper::isGroupActive for faster navigation checks
- streamline URL path handling

## Testing
- `php ./vendor/bin/phpunit` *(fails: SQLSTATE[HY000]: General error: 1 no such table: permissions)*

------
https://chatgpt.com/codex/tasks/task_e_68a18096e6a88333a77cd0f4d74b0137